### PR TITLE
Echidna config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+
+branches:
+  only:
+    - /.*/
+
 python:
   - "2.7_with_system_site_packages"
 sudo: false
@@ -25,3 +30,12 @@ install:
  - make travissetup
 script:
  - make check
+
+env:
+  global:
+    - URL="https://w3c.github.io/mediacapture-output/W3CTRMANIFEST"
+    - DECISION="https://lists.w3.org/Archives/Public/public-media-capture/2015Dec/0031.html"
+    - secure: "IxbwoPaIvdMg2LhW484WL3cYoXNujggRF/gQnQt2RVvvB6RrLXqC1AKv9rHIQ5hzsCO+c0hjEA/TBGJ1OWPbyMZ6ZitEUdj6AfCIVIpKVWYg0yvephWbsUxAyVdeUKxuTnilW/AsewZt94jAfhSWwf0Dy4t5qA0SsJV+TO/uURc="
+
+after_success:
+  - test $TRAVIS_BRANCH = "gh-pages" -a $TRAVIS_PULL_REQUEST = false && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"

--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,2 +1,2 @@
-index.html?shortName=audio-output respec
+index.html?specStatus=WD;shortName=audio-output respec
 style.css

--- a/script.js
+++ b/script.js
@@ -52,7 +52,7 @@ var respecConfig = {
    wg: ["Device and Sensors Working Group", "Web Real-Time Communications Working Group"],
 
    // URI of the public WG page
-   wgURI: ["http://www.w3.org/2009/dap/", "http://www.w3.org/2011/04/webrtc/"]
+   wgURI: ["http://www.w3.org/2009/dap/", "http://www.w3.org/2011/04/webrtc/"],
 
    // name (without the @w3.org) of the public mailing to which comments are due
    wgPublicList: "public-media-capture",

--- a/script.js
+++ b/script.js
@@ -20,7 +20,7 @@ var respecConfig = {
    // prevED: "",
 
    // if there a publicly available Editor's Draft, this is the link
-   edDraftURI: "http://w3c.github.io/mediacapture-output/",
+   edDraftURI: "https://w3c.github.io/mediacapture-output/",
 
    // if this is a LCWD, uncomment and set the end of its review period
    // lcEnd: "2009-08-05",
@@ -35,8 +35,8 @@ var respecConfig = {
    editors:  [
        // { name: "Your Name", url: "http://example.org/",
        // company: "Your Company", companyURL: "http://example.com/" },
-       { name: "Justin Uberti", company: "Google" },
-       { name: "Guido Urdaneta", company: "Google" }
+       { name: "Justin Uberti", company: "Google", w3cid: 51065 },
+       { name: "Guido Urdaneta", company: "Google", w3cid: 84810 }
    ],
 
    // authors, add as many as you like.
@@ -49,10 +49,10 @@ var respecConfig = {
    //],
 
    // name of the WG
-   wg: ["Web Real-Time Communication Working Group", "Device APIs Working Group"]          ,
+   wg: ["Device and Sensors Working Group", "Web Real-Time Communications Working Group"],
 
    // URI of the public WG page
-   wgURI:["http://www.w3.org/2011/04/webrtc/","http://www.w3.org/2009/dap"],
+   wgURI: ["http://www.w3.org/2009/dap/", "http://www.w3.org/2011/04/webrtc/"]
 
    // name (without the @w3.org) of the public mailing to which comments are due
    wgPublicList: "public-media-capture",
@@ -62,7 +62,7 @@ var respecConfig = {
    // This is important for Rec-track documents, do not copy a patent URI from a random
    // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
    // Team Contact.
-   wgPatentURI:   ["http://www.w3.org/2004/01/pp-impl/47318/status","http://www.w3.org/2004/01/pp-impl/43696/status"],
+   wgPatentURI: ["http://www.w3.org/2004/01/pp-impl/43696/status", "http://www.w3.org/2004/01/pp-impl/47318/status"],
 
    // Bug tracker and mailing list info
    issueBase: "https://github.com/w3c/mediacapture-output/issues/",
@@ -72,7 +72,7 @@ var respecConfig = {
       data: [
         {
           value: "Mailing list",
-          href: "http://lists.w3.org/Archives/Public/public-media-capture/"
+          href: "https://lists.w3.org/Archives/Public/public-media-capture/"
         },
         {
           value: "Browse open issues",


### PR DESCRIPTION
Per https://github.com/w3c/echidna/wiki/How-to-use-Echidna-with-ReSpec-and-GitHub
and https://github.com/w3c/echidna/wiki/Setting-up-Echidna-as-a-GitHub-hook

Also fix WG names:
Device APIs WG is now called Device and Sensors WG
Alphabetical order of groups

Use https for the github.io edDraftURI and lists.w3.org link