### PR TITLE
Remove duplicate info on method parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,31 +81,6 @@
             be rendered if the application is <a href=
             "#privacy-considerations">authorized</a> to play out of a given
             device.
-            <table class="parameters">
-              <tbody>
-                <tr>
-                  <th>Parameter</th>
-                  <th>Type</th>
-                  <th>Nullable</th>
-                  <th>Optional</th>
-                  <th>Description</th>
-                </tr>
-                <tr>
-                  <td class="prmName">sinkId</td>
-                  <td class="prmType"><code>DOMString</code></td>
-                  <td class="prmNullFalse"><span role="img" aria-label=
-                  "False">✘</span></td>
-                  <td class="prmOptFalse"><span role="img" aria-label=
-                  "False">✘</span></td>
-                  <td class="prmDesc">The ID corresponding to the audio output
-                  device. The empty string represents the user agent
-                  default.</td>
-                </tr>
-              </tbody>
-            </table>
-            <div>
-              <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-            </div>
           </dd>
         </dl>
       </section>


### PR DESCRIPTION
These were inherited from the previous respec WebIDL format, but they now represent a maintenance footgun
See also https://github.com/w3c/webrtc-pc/pull/1450