### PR TITLE
Initialize [[SinkId]] to "".

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <ol>
       <li>
         <p>Let the element have a <dfn>[[\SinkId]]</dfn> internal slot,
-        initialized to <code>null</code>.
+        initialized to <code>""</code>.
       </li>
     </ol>
     <div>


### PR DESCRIPTION
Fix for https://github.com/w3c/mediacapture-output/issues/79.