### PR TITLE
Make setSinkId and sinkId SecureContext.

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@
     <div>
       <pre class="idl">
       partial interface HTMLMediaElement {
-        readonly        attribute DOMString sinkId;
-        Promise&lt;void&gt; setSinkId (DOMString sinkId);
+        [SecureContext] readonly attribute DOMString sinkId;
+        [SecureContext] Promise&lt;void&gt; setSinkId (DOMString sinkId);
       };
       </pre>
       <section>


### PR DESCRIPTION
Fix for https://github.com/w3c/mediacapture-output/issues/78.