### PR TITLE
Add deviceId option to selectAudioOutput()

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,7 +335,7 @@
             <h2>Dictionary <dfn>AudioOutputOptions</dfn> Members</h2>
             <dl data-link-for="AudioOutputOptions" data-dfn-for="AudioOutputOptions"
             class="dictionary-members">
-              <dt data-tests="RTCPeerConnection-restartIce.https.html"><dfn data-idl>deviceId</dfn> of type <span class=
+              <dt><dfn data-idl>deviceId</dfn> of type <span class=
                 "idlMemberType">DOMString</span>, defaulting to
               <code>""</code></dt>
               <dd>

--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@
       </section>
       <section>
         <h4>AudioOutputOptions dictionary</h4>
-        <p>This dictionary describe the options that can be used to obtain
+        <p>This dictionary describes the options that can be used to obtain
         access to an audio output device.</p>
         <div>
           <pre class="idl"

--- a/index.html
+++ b/index.html
@@ -293,14 +293,17 @@
                       ><code>"denied"</code></a>, reject
                       <var>p</var> with a new <code>DOMException</code> whose
                       <code>name</code> attribute has the value
-                    <code>NotAllowedError</code> and abort these steps.</p>
+                    <code>NotAllowedError</code>, and abort these steps.</p>
                   </li>
                   <li><p>Probe the User Agent for available audio output devices.</p></li>
-                  <li><p>If there is no audio output device, reject
-                  <var>p</var> with a new <code>DOMException</code> whose <code>name</code> attribute
-                  has the value <code>NotFoundError</code>.</p></li>
                   <li>
-                    <p class="fingerprint">If <var>deviceId</code> is not
+                    <p>If there is no audio output device, reject <var>p</var>
+                    with a new <code>DOMException</code> whose <code>name</code>
+                    attribute has the value <code>NotFoundError</code> and abort
+                    these steps.</p>
+                  </li>
+                  <li>
+                    <p class="fingerprint">If <var>deviceId</var> is not
                     <code>""</code> and matches an id previously exposed by
                     <code>selectAudioOutput</code> in an earlier browsing
                     session, the user agent MAY decide, based on its previous
@@ -309,18 +312,18 @@
                     <ol>
                       <li>
                         <p>Let <var>device</var> be the device identified by
-                        <var>deviceId</var>.</p>
+                        <var>deviceId</var>, if available.</p>
                       </li>
                       <li><p>If <var>device</var> is available, resolve
                       <var>p</var> with either <var>deviceId</var> or a freshly
-                      rotated deviceId for <var>device</var>, and abort the
+                      rotated device id for <var>device</var>, and abort the
                       in-parallel steps.</p></li>
                     </ol>
                   </li>
                   <li><p><a data-cite="PERMISSIONS#prompt-the-user-to-choose">
                   Prompt the user to choose</a> an audio output device, with
                   <var>descriptor</var>.</p></li>
-                  <li><p>If the result of the request is "denied", reject
+                  <li><p>If the result of the request is <code>"denied"</code>, reject
                     <var>p</var> with a new <code>DOMException</code> whose <code>name</code> attribute
                     has the value <code>NotAllowedError</code> and abort these steps.</p></li>
                   <li><p>Let <var>deviceInfo</var> be a new <code>MediaDeviceInfo</code> object to represent the selected audio output device.</p></li>

--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
     <div>
       <pre class="idl">
       partial interface MediaDevices {
-        Promise&lt;MediaDeviceInfo&gt; selectAudioOutput();
+        Promise&lt;MediaDeviceInfo&gt; selectAudioOutput(optional AudioOutputOptions options = {});
       };
       </pre>
       <section>
@@ -276,6 +276,8 @@
               return a promise rejected with a <code>DOMException</code> object whose
               <code>name</code> attribute has the value <code>InvalidStateError</code>.
               </p></li>
+              <li><p>Let <var>options</var> be the method's first argument.</p></li>
+              <li><p>Let <var>deviceId</var> be <var>options</var><code>.deviceId</code>.</p></li>
               <li><p>Let <var>p</var> be a new promise.</p></li>
               <li>
                 <p>Run the following steps in parallel:</p>
@@ -284,6 +286,19 @@
                   <li><p>If there is no audio output device, reject
                   <var>p</var> with a new <code>DOMException</code> whose <code>name</code> attribute
                   has the value <code>NotFoundError</code>.</p></li>
+                  <li>
+                    <p>If <var>deviceId</code> is not <code>""</code>, and
+                    matches an id previously exposed by
+                    <code>selectAudioOutput</code> in an earlier browsing
+                    session, the user agent MAY decide to run the following
+                    sub steps:</p>
+                    <ol>
+                      <li>
+                        <p>Let <var>device</var> be the device identified by <var>deviceId</var>.</p>
+                      </li>
+                      <li><p>Resolve <var>p</var> with either <var>deviceInfo</var>.</p></li>
+                    </ol>
+                  </li>
                   <li><p><a data-cite="PERMISSIONS#prompt-the-user-to-choose">
                   Prompt the user to choose</a> an audio output device, with a PermissionDescriptor
                   named <code>"speaker-selection"</code>.</p></li>
@@ -306,6 +321,34 @@
             within these fulfillment handlers without any additional user gesture needed.</p>
           </dd>
         </dl>
+      </section>
+      <section>
+        <h4>AudioOutputOptions dictionary</h4>
+        <p>This dictionary describe the options that can be used to obtain
+        access to an audio output device.</p>
+        <div>
+          <pre class="idl"
+>dictionary AudioOutputOptions {
+  DOMString deviceId = "";
+};</pre>
+          <section>
+            <h2>Dictionary <dfn>AudioOutputOptions</dfn> Members</h2>
+            <dl data-link-for="AudioOutputOptions" data-dfn-for="AudioOutputOptions"
+            class="dictionary-members">
+              <dt data-tests="RTCPeerConnection-restartIce.https.html"><dfn data-idl>deviceId</dfn> of type <span class=
+                "idlMemberType">DOMString</span>, defaulting to
+              <code>""</code></dt>
+              <dd>
+                <p>When the value of this dictionary member is not <code>""</code>,
+                and matches the id previously exposed by
+                <code>selectAudioOutput</code> in an earlier session, the user
+                agent MAY opt to skip prompting the user in favor of resolving
+                with this id or a new rotated id for the same device, assuming
+                that device is currently available.</p>
+              </dd>
+            </dl>
+          </section>
+        </div>
       </section>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -360,12 +360,19 @@
                 "idlMemberType">DOMString</span>, defaulting to
               <code>""</code></dt>
               <dd>
-                <p>When the value of this dictionary member is not <code>""</code>,
-                and matches the id previously exposed by
+                <p class="fingerprint">When the value of this dictionary member
+                is not <code>""</code>, and matches the id previously exposed by
                 <code>selectAudioOutput</code> in an earlier session, the user
                 agent MAY opt to skip prompting the user in favor of resolving
                 with this id or a new rotated id for the same device, assuming
                 that device is currently available.</p>
+                <p class="note">Applications that wish to rely on user agents
+                supporting persisted device ids must pass these through
+                <code>selectAudioOutput</code> successfully before they will
+                work with <code>setSinkId</code>. The reason for this is that it
+                exposes fingerprinting information, but at the risk of prompting
+                the user if the device is not available or the user agent
+                decides not to honor the device id.</p>
               </dd>
             </dl>
           </section>

--- a/index.html
+++ b/index.html
@@ -296,7 +296,8 @@
                       <li>
                         <p>Let <var>device</var> be the device identified by <var>deviceId</var>.</p>
                       </li>
-                      <li><p>Resolve <var>p</var> with either <var>deviceInfo</var> and abort all steps.</p></li>
+                      <li><p>Resolve <var>p</var> with either <var>deviceId</var> or a freshly
+                      rotated deviceId for <var>device</var>, and abort all steps.</p></li>
                     </ol>
                   </li>
                   <li><p><a data-cite="PERMISSIONS#prompt-the-user-to-choose">

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
                   </li>
                   <li>
                     <p>If <var>descriptor</var>'s
-                    <a data-cite="PERMISSIONS/#dom-permissionstate"
+                    <a data-cite="PERMISSIONS/#permission-state"
                       >permission state</a> is
                     <a data-cite="PERMISSIONS/#dom-permissionstate-granted"
                       ><code>"denied"</code></a>, reject

--- a/index.html
+++ b/index.html
@@ -296,7 +296,7 @@
                       <li>
                         <p>Let <var>device</var> be the device identified by <var>deviceId</var>.</p>
                       </li>
-                      <li><p>Resolve <var>p</var> with either <var>deviceInfo</var>.</p></li>
+                      <li><p>Resolve <var>p</var> with either <var>deviceInfo</var> and abort all steps.</p></li>
                     </ol>
                   </li>
                   <li><p><a data-cite="PERMISSIONS#prompt-the-user-to-choose">

--- a/index.html
+++ b/index.html
@@ -282,27 +282,44 @@
               <li>
                 <p>Run the following steps in parallel:</p>
                 <ol>
+                  <li><p>Let <var>descriptor</var> be a PermissionDescriptor named
+                    <code>"speaker-selection"</code>.</p>
+                  </li>
+                  <li>
+                    <p>If <var>descriptor</var>'s
+                    <a data-cite="PERMISSIONS/#dom-permissionstate"
+                      >permission state</a> is
+                    <a data-cite="PERMISSIONS/#dom-permissionstate-granted"
+                      ><code>"denied"</code></a>, reject
+                      <var>p</var> with a new <code>DOMException</code> whose
+                      <code>name</code> attribute has the value
+                    <code>NotAllowedError</code> and abort these steps.</p>
+                  </li>
                   <li><p>Probe the User Agent for available audio output devices.</p></li>
                   <li><p>If there is no audio output device, reject
                   <var>p</var> with a new <code>DOMException</code> whose <code>name</code> attribute
                   has the value <code>NotFoundError</code>.</p></li>
                   <li>
-                    <p>If <var>deviceId</code> is not <code>""</code>, and
-                    matches an id previously exposed by
+                    <p class="fingerprint">If <var>deviceId</code> is not
+                    <code>""</code> and matches an id previously exposed by
                     <code>selectAudioOutput</code> in an earlier browsing
-                    session, the user agent MAY decide to run the following
-                    sub steps:</p>
+                    session, the user agent MAY decide, based on its previous
+                    decision of whether to persist this id or not for this set
+                    of origins, to run the following sub steps:</p>
                     <ol>
                       <li>
-                        <p>Let <var>device</var> be the device identified by <var>deviceId</var>.</p>
+                        <p>Let <var>device</var> be the device identified by
+                        <var>deviceId</var>.</p>
                       </li>
-                      <li><p>Resolve <var>p</var> with either <var>deviceId</var> or a freshly
-                      rotated deviceId for <var>device</var>, and abort all steps.</p></li>
+                      <li><p>If <var>device</var> is available, resolve
+                      <var>p</var> with either <var>deviceId</var> or a freshly
+                      rotated deviceId for <var>device</var>, and abort the
+                      in-parallel steps.</p></li>
                     </ol>
                   </li>
                   <li><p><a data-cite="PERMISSIONS#prompt-the-user-to-choose">
-                  Prompt the user to choose</a> an audio output device, with a PermissionDescriptor
-                  named <code>"speaker-selection"</code>.</p></li>
+                  Prompt the user to choose</a> an audio output device, with
+                  <var>descriptor</var>.</p></li>
                   <li><p>If the result of the request is "denied", reject
                     <var>p</var> with a new <code>DOMException</code> whose <code>name</code> attribute
                     has the value <code>NotAllowedError</code> and abort these steps.</p></li>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-output/issues/99 (as a proposal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-output/pull/104.html" title="Last updated on Aug 20, 2020, 2:19 PM UTC (ae36d78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-output/104/f3ccc25...jan-ivar:ae36d78.html" title="Last updated on Aug 20, 2020, 2:19 PM UTC (ae36d78)">Diff</a>