### PR TITLE
Fix permissionstate link

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
                     <p>If <var>descriptor</var>'s
                     <a data-cite="PERMISSIONS/#permission-state"
                       >permission state</a> is
-                    <a data-cite="PERMISSIONS/#dom-permissionstate-granted"
+                    <a data-cite="PERMISSIONS/#dom-permissionstate-denied"
                       ><code>"denied"</code></a>, reject
                       <var>p</var> with a new <code>DOMException</code> whose
                       <code>name</code> attribute has the value


### PR DESCRIPTION
I noticed a little typo (at least I think it's a typo) in the latest pull request. There is a link which points to the `granted` permission state while the text mentions the `denied` state. This pull request is meant to fix that.

Please let me know if there is anything I need to change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisguttandin/mediacapture-output/pull/106.html" title="Last updated on Aug 20, 2020, 5:36 PM UTC (abf72eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-output/106/8c6b5de...chrisguttandin:abf72eb.html" title="Last updated on Aug 20, 2020, 5:36 PM UTC (abf72eb)">Diff</a>