### PR TITLE
Fix default allowlist link that broke.

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
           <dd>
             <p>Prompts the user to select a specific audio output device.</p>
             <p>When the {{selectAudioOutput}} method is called,
-            the User Agent MUST run the following steps:</p>
+            the [=user agent=] MUST run the following steps:</p>
             <ol>
               <li><p>If the [=relevant global object=] of [=this=] does not have
                 [=transient activation=], return a promise <a>rejected</a> with
@@ -266,7 +266,7 @@
                       {{DOMException/name}} attribute has the value
                     {{NotAllowedError}}, and abort these steps.</p>
                   </li>
-                  <li><p>Probe the User Agent for available audio output devices.</p></li>
+                  <li><p>Probe the [=user agent=] for available audio output devices.</p></li>
                   <li>
                     <p>If there is no audio output device, reject <var>p</var>
                     with a new {{DOMException}} whose {{DOMException/name}}

--- a/index.html
+++ b/index.html
@@ -503,8 +503,8 @@
       <p>This specification defines one
       [=policy-controlled feature=] identified by the string
       <code><dfn>"speaker-selection"</dfn></code>.
-      It has a
-      [=default allowlist=] of <code class=featurepolicy>"self"</code>.
+      It has a [=policy-controlled feature/default allowlist=]
+      of <code class=featurepolicy>"self"</code>.
       <div class="note">
         <p>A [=document=]'s [=Document/permissions policy=]
         determines whether any content in that document is

--- a/script.js
+++ b/script.js
@@ -1,3 +1,6 @@
+let aMonthFromNow = new Date();
+aMonthFromNow.setMonth(aMonthFromNow.getMonth() + 1);
+
 var respecConfig = {
    // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
    specStatus:           "ED",

--- a/script.js
+++ b/script.js
@@ -29,7 +29,7 @@ var respecConfig = {
    // it is recommended that the respec.css stylesheet be kept
    //extraCSS:             ["http://dev.w3.org/2009/dap/ReSpec.js/css/respec.css"],
    //extraCSS:           ["../../../2009/dap/ReSpec.js/css/respec.css"],
-  crEnd: aMonthFromNow.toJSON().slice(0,10),
+   crEnd: aMonthFromNow.toJSON().slice(0,10),
    // editors, add as many as you like
    // only "name" is required
    editors:  [

--- a/script.js
+++ b/script.js
@@ -29,7 +29,7 @@ var respecConfig = {
    // it is recommended that the respec.css stylesheet be kept
    //extraCSS:             ["http://dev.w3.org/2009/dap/ReSpec.js/css/respec.css"],
    //extraCSS:           ["../../../2009/dap/ReSpec.js/css/respec.css"],
-
+  crEnd: aMonthFromNow.toJSON().slice(0,10),
    // editors, add as many as you like
    // only "name" is required
    editors:  [


### PR DESCRIPTION
Fixes respec error.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-output/pull/134.html" title="Last updated on Jan 16, 2023, 11:03 AM UTC (a24c594)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-output/134/fb29ebd...jan-ivar:a24c594.html" title="Last updated on Jan 16, 2023, 11:03 AM UTC (a24c594)">Diff</a>