### PR TITLE
Remove deviceId from permission, and make granted = any

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,24 +455,28 @@
         </dt>
         <dd>
           <p>
-            A permission covers access to the device given in the associated
-            {{DevicePermissionDescriptor}} descriptor.
+            A permission covers access to at least one non-default speaker output device.
           </p>
           <p>
-            If the descriptor does not have a {{DevicePermissionDescriptor/deviceId}}, its
-            semantic is that it queries for access to all devices of that class. Thus, if a query
-            for the "speaker-selection" [=powerful feature=] with no
-            {{DevicePermissionDescriptor/deviceId}} returns {{PermissionState/"granted"}}, the
-            client knows that there will not be a permission prompt for any audio output device
-            known to it, if requested using the {{AudioOutputOptions/deviceId}} option to
-            {{MediaDevices/selectAudioOutput}},
-            and if {{PermissionState/"denied"}} is returned, it knows that no selectAudioOutput request
+            The semantics of the descriptor is that it queries for access to any non-default speaker
+            output device. Thus, if a query for the "speaker-selection" [=powerful feature=] returns
+            {{PermissionState/"granted"}}, the client knows that at least one of the
+            {{AudioOutputOptions/deviceId}}s previously shared with it can be passed to
+            {{MediaDevices/selectAudioOutput}} without incurring a permission prompt,
+            and if {{PermissionState/"denied"}} is returned, it knows that no {{MediaDevices/selectAudioOutput}} request
             for an audio output device will succeed.
           </p>
           <p>
+            If the User Agent considers permission given to some, but not all, audio output devices,
+            a query will return {{PermissionState/"granted"}}.
+          </p>
+          <p>
+            If the User Agent considers permission denied to all audio output devices, a query
+            will return {{PermissionState/"denied"}}.
+          </p>
+          <p>
             If a permission state is present for access to some, but not all, audio output devices,
-            a query without the {{DevicePermissionDescriptor/deviceId}} will return
-            {{PermissionState/"prompt"}}.
+            a query will return {{PermissionState/"prompt"}}.
           </p>
         </dd>
         <dt>

--- a/index.html
+++ b/index.html
@@ -474,10 +474,6 @@
             If the User Agent considers permission denied to all audio output devices, a query
             will return {{PermissionState/"denied"}}.
           </p>
-          <p>
-            If a permission state is present for access to some, but not all, audio output devices,
-            a query will return {{PermissionState/"prompt"}}.
-          </p>
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -479,39 +479,6 @@
             a query will return {{PermissionState/"prompt"}}.
           </p>
         </dd>
-        <dt>
-          [=powerful feature/extra permission data type=]
-        </dt>
-        <dd>
-          A list of {{MediaDeviceInfo/deviceId}} values for the devices the user has made a
-          non-default decision on access to.
-        </dd>
-        <dt>
-          [=powerful feature/permission query algorithm=]
-        </dt>
-        <dd>
-          The permission query algorithm runs the following steps:
-          <ol class="algorithm">
-            <li>If |permissionDesc|.deviceId exists in the [=powerful feature/extra permission
-            data=], set <code>|status|.state</code> to |permissionDesc|'s <a>permission state</a>
-            and terminate these steps.
-            </li>
-            <li>Let <var>global</var> be a copy of |permissionDesc| with the
-            {{DevicePermissionDescriptor/deviceId}} member removed.
-            </li>
-            <li>Set <code>|status|.state</code> to <var>global</var>'s <a>permission state</a>.
-            </li>
-          </ol>
-        </dd>
-        <dt>
-          [=powerful feature/permission revocation algorithm=]
-        </dt>
-        <dd>
-          This is the result of calling the [=device permission revocation algorithm=] passing
-          {{PermissionDescriptor/name}} and {{DevicePermissionDescriptor/deviceId}} as arguments.
-          If the descriptor does not have a {{DevicePermissionDescriptor/deviceId}}, then
-          <code>undefined</code> is passed in place of {{DevicePermissionDescriptor/deviceId}}.
-        </dd>
       </dl>
     </section>
     <section>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-main/issues/965.
Fixes #138.

cc @youennf, @karlt


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-output/pull/139.html" title="Last updated on Aug 21, 2023, 4:29 PM UTC (feb94c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-output/139/e450f85...jan-ivar:feb94c8.html" title="Last updated on Aug 21, 2023, 4:29 PM UTC (feb94c8)">Diff</a>