### PR TITLE
Allow prompt bypass for miked speakers exposed through getUserMedia()

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
                     <p class="fingerprint">If <var>deviceId</var> is not
                     <code>""</code> and matches an audio output device id previously
                     exposed by {{MediaDevices/selectAudioOutput}} or
-                    {{MediaDevices/enumerateDevices()}} in an earlier browsing
+                    {{MediaDevices/getUserMedia()}} in an earlier browsing
                     session, the user agent MAY decide, based on its previous
                     decision of whether to persist this id or not for this set
                     of origins, to run the following sub steps:</p>
@@ -345,7 +345,8 @@
               <dd>
                 <p class="fingerprint">When the value of this dictionary member
                 is not <code>""</code>, and matches the id previously exposed by
-                {{MediaDevices/selectAudioOutput}} in an earlier session, the user
+                {{MediaDevices/selectAudioOutput}} or
+                {{MediaDevices/getUserMedia()}} in an earlier session, the user
                 agent MAY opt to skip prompting the user in favor of resolving
                 with this id or a new rotated id for the same device, assuming
                 that device is currently available.</p>

--- a/index.html
+++ b/index.html
@@ -276,22 +276,30 @@
                     these steps.</p>
                   </li>
                   <li>
-                    <p class="fingerprint">If <var>deviceId</var> is not
-                    <code>""</code> and matches an audio output device id previously
-                    exposed by {{MediaDevices/selectAudioOutput}} or
-                    {{MediaDevices/getUserMedia()}} in an earlier browsing
-                    session, the user agent MAY decide, based on its previous
-                    decision of whether to persist this id or not for this set
-                    of origins, to run the following sub steps:</p>
+                    <p>If <var>deviceId</var> is not <code>""</code>
+                    run the following sub steps:</p>
                     <ol>
                       <li>
-                        <p>Let <var>device</var> be the device identified by
-                        <var>deviceId</var>, if available.</p>
+                        <p class="fingerprint">If <var>deviceId</var> matches a
+                        a device id previously exposed by
+                        {{MediaDevices/selectAudioOutput}} in an earlier browsing
+                        session, or matches a device id of an audio output device
+                        with the same groupId as an audio input device previously
+                        exposed by {{MediaDevices/getUserMedia()}} in an earlier browsing
+                        session, the user agent MAY decide, based on its previous
+                        decision of whether to persist this id or not for this set
+                        of origins, to run the following sub steps:</p>
+                        <ol>
+                          <li>
+                            <p>Let <var>device</var> be the device identified by
+                            <var>deviceId</var>, if available.</p>
+                          </li>
+                          <li><p>If <var>device</var> is available, resolve
+                          <var>p</var> with either <var>deviceId</var> or a freshly
+                          rotated device id for <var>device</var>, and abort the
+                          in-parallel steps.</p></li>
+                        </ol>
                       </li>
-                      <li><p>If <var>device</var> is available, resolve
-                      <var>p</var> with either <var>deviceId</var> or a freshly
-                      rotated device id for <var>device</var>, and abort the
-                      in-parallel steps.</p></li>
                     </ol>
                   </li>
                   <li><p>[=Prompt the user to choose=] an audio output device, with
@@ -346,6 +354,8 @@
                 <p class="fingerprint">When the value of this dictionary member
                 is not <code>""</code>, and matches the id previously exposed by
                 {{MediaDevices/selectAudioOutput}} or
+                a device id of an audio output device with the same groupId as an
+                audio input device previously exposed by
                 {{MediaDevices/getUserMedia()}} in an earlier session, the user
                 agent MAY opt to skip prompting the user in favor of resolving
                 with this id or a new rotated id for the same device, assuming

--- a/index.html
+++ b/index.html
@@ -282,10 +282,10 @@
                       <li>
                         <p class="fingerprint">If <var>deviceId</var> matches a
                         a device id previously exposed by
-                        {{MediaDevices/selectAudioOutput}} in an earlier browsing
+                        {{MediaDevices/selectAudioOutput}} in this or an earlier browsing
                         session, or matches a device id of an audio output device
                         with the same groupId as an audio input device previously
-                        exposed by {{MediaDevices/getUserMedia()}} in an earlier browsing
+                        exposed by {{MediaDevices/getUserMedia()}} in this or an earlier browsing
                         session, the user agent MAY decide, based on its previous
                         decision of whether to persist this id or not for this set
                         of origins, to run the following sub steps:</p>
@@ -356,7 +356,7 @@
                 {{MediaDevices/selectAudioOutput}} or
                 a device id of an audio output device with the same groupId as an
                 audio input device previously exposed by
-                {{MediaDevices/getUserMedia()}} in an earlier session, the user
+                {{MediaDevices/getUserMedia()}} in this or an earlier session, the user
                 agent MAY opt to skip prompting the user in favor of resolving
                 with this id or a new rotated id for the same device, assuming
                 that device is currently available.</p>

--- a/index.html
+++ b/index.html
@@ -277,8 +277,9 @@
                   </li>
                   <li>
                     <p class="fingerprint">If <var>deviceId</var> is not
-                    <code>""</code> and matches an id previously exposed by
-                    {{MediaDevices/selectAudioOutput}} in an earlier browsing
+                    <code>""</code> and matches an audio output device id previously
+                    exposed by {{MediaDevices/selectAudioOutput}} or
+                    {{MediaDevices/enumerateDevices()}} in an earlier browsing
                     session, the user agent MAY decide, based on its previous
                     decision of whether to persist this id or not for this set
                     of origins, to run the following sub steps:</p>


### PR DESCRIPTION
Fixes #142.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-output/pull/143.html" title="Last updated on Aug 29, 2024, 3:02 PM UTC (e8f3587)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-output/143/c29658f...jan-ivar:e8f3587.html" title="Last updated on Aug 29, 2024, 3:02 PM UTC (e8f3587)">Diff</a>